### PR TITLE
Rewrite for readability and use ffmpeg-python library

### DIFF
--- a/ffmpegify.py
+++ b/ffmpegify.py
@@ -160,6 +160,7 @@ class FFMPEGIFY():
             pass
         return cmd
 
+
     def add_scaling(self, cmd):
         # scale down video if the image dimensions exceed the max width or height, while maintaining aspect ratio
         if self.MAX_HEIGHT <= 0 and self.MAX_WIDTH <= 0:
@@ -188,6 +189,7 @@ class FFMPEGIFY():
             cmd.extend(('-vf', scalestr))
         cmd.extend(('-sws_flags', self.SCALER))
         return cmd
+
 
     def build_output(self, outputf, cmd):
         if self.isVidOut:
@@ -220,6 +222,21 @@ class FFMPEGIFY():
 
         return cmd
 
+    def video_to_video(self, infile, cmd):
+        # ==================================
+        # Vid-Vid conversion (with audio)
+        # TODO
+        # ==================================
+        stem = infile.stem
+        cmd.extend(('-i', infile))
+        saveDir = infile
+        if self.CODEC == "H.264":
+            cmd.extend(('-c:v', 'libx264'))
+            cmd.extend(('-pix_fmt', 'yuv420p', '-crf', str(self.CRF), '-preset', self.PRESET))
+
+        outputf = str(saveDir.with_name(stem + "_converted." + self.VIDFORMAT))
+        cmd.append(outputf)
+
 
     def convert(self, path):
         infile = self.get_input_file(path)
@@ -247,18 +264,8 @@ class FFMPEGIFY():
             cmd = self.build_output(outputf, cmd)
             subprocess.run(cmd)
 
-        # ==================================
-        # Vid-Vid conversion (with audio)
-        # TODO
-        # ==================================
         elif suffix in vid_suff:
-            cmd.extend(('-i', infile))
-            if self.CODEC == "H.264":
-                cmd.extend(('-c:v', 'libx264'))
-                cmd.extend(('-pix_fmt', 'yuv420p', '-crf', str(self.CRF), '-preset', self.PRESET))
-
-            outputf = str(saveDir.with_name(stem + "_converted." + self.VIDFORMAT))
-            cmd.append(outputf)
+            cmd = self.video_to_video(cmd)
             subprocess.run(cmd)
         else:
             print("Invalid file extension")

--- a/ffmpegify.py
+++ b/ffmpegify.py
@@ -46,8 +46,8 @@ class FFMPEGIFY():
         if self.VIDFORMAT not in vids:
             isVidOut = False
 
-        file = pathlib.Path(path)
-        saveDir = file  # set the directory to save the output to
+        infile = pathlib.Path(path)
+        saveDir = infile  # set the directory to save the output to
 
         # For Directories
         if os.path.isdir(path):
@@ -55,10 +55,10 @@ class FFMPEGIFY():
             for f in files:
                 fpath = pathlib.Path(f)
                 if fpath.suffix in alltypes:
-                    file = file.joinpath(fpath)
+                    infile = infile.joinpath(fpath)
                     break
-        stem = file.stem
-        suffix = file.suffix
+        stem = infile.stem
+        suffix = infile.suffix
 
         # create ffmpeg command to append to
         platform = sys.platform
@@ -82,7 +82,7 @@ class FFMPEGIFY():
                 # glob for other frames in the folder and find the first frame to use as start number
                 preframepart = stem[0:sp2[0]]
                 postframepart = stem[sp2[1]:]
-                frames = sorted(file.parent.glob(preframepart + '*' + postframepart + suffix))
+                frames = sorted(infile.parent.glob(preframepart + '*' + postframepart + suffix))
                 start_num = int(frames[0].name[sp2[0]:sp2[1]])
                 if self.START_FRAME > 0:
                     start_num = self.START_FRAME
@@ -96,16 +96,16 @@ class FFMPEGIFY():
 
                 # get absolute path to the input file and set the outputfile
                 inputf = stem[0:sp2[0]] + padstring + postframepart + suffix
-                inputf_abs = str(file.with_name(inputf))
+                inputf_abs = str(infile.with_name(inputf))
 
                 # naming the video file based on parent dirs
-                parts = file.parent.parts
+                parts = infile.parent.parts
                 if (self.NAME_LEVELS > 0):
                     sec = len(parts) - self.NAME_LEVELS
                     parts = parts[sec:]
                     outname = "_".join(parts)
                 else:
-                    outname = str(file.parent)
+                    outname = str(infile.parent)
                 outname = re.sub(r'\W+', '_', outname)
 
                 outputf = str(saveDir.with_name('_' + outname + "_video." + self.VIDFORMAT))
@@ -142,7 +142,7 @@ class FFMPEGIFY():
                 # ffprobe = ['ffprobe']
                 # ffprobe.extend(('-v', 'quiet'))
                 # ffprobe.extend(('-print_format', 'json'))
-                # ffprobe.append(str(file))
+                # ffprobe.append(str(infile))
                 # ffprobe.append('-show_format')
                 # ffprobe.append('-show_streams')
                 # ffpr = subprocess.check_output(ffprobe)
@@ -163,11 +163,11 @@ class FFMPEGIFY():
                 # AUDIO
                 try:
                     tracks = []
-                    tracks.extend(sorted(file.parent.glob('*.mp3')))
-                    tracks.extend(sorted(file.parent.glob('*.wav')))
+                    tracks.extend(sorted(infile.parent.glob('*.mp3')))
+                    tracks.extend(sorted(infile.parent.glob('*.wav')))
                     # also search immediate parent?
-                    tracks.extend(sorted(file.parents[1].glob('*.mp3')))
-                    tracks.extend(sorted(file.parents[1].glob('*.wav')))
+                    tracks.extend(sorted(infile.parents[1].glob('*.mp3')))
+                    tracks.extend(sorted(infile.parents[1].glob('*.wav')))
                     if (tracks):
                         self.AUDIO = True
                         # audio track offset - add controls for this?
@@ -215,7 +215,7 @@ class FFMPEGIFY():
         # TODO
         # ==================================
         elif suffix in vid_suff:
-            cmd.extend(('-i', file))
+            cmd.extend(('-i', infile))
             if self.CODEC == "H.264":
                 cmd.extend(('-c:v', 'libx264'))
                 cmd.extend(('-pix_fmt', 'yuv420p', '-crf', str(self.CRF), '-preset', self.PRESET))

--- a/ffmpegify.py
+++ b/ffmpegify.py
@@ -131,6 +131,23 @@ class FFMPEGIFY():
         return (None, None, None)
 
 
+    def add_audio(self, infile, cmd):
+        # AUDIO
+        try:
+            tracks = []
+            tracks.extend(sorted(infile.parent.glob('*.mp3')))
+            tracks.extend(sorted(infile.parent.glob('*.wav')))
+            # also search immediate parent?
+            tracks.extend(sorted(infile.parents[1].glob('*.mp3')))
+            tracks.extend(sorted(infile.parents[1].glob('*.wav')))
+            if (tracks):
+                self.AUDIO = True
+                # audio track offset - add controls for this?
+                cmd.extend(('-itsoffset', str(self.AUDIO_OFFSET)))
+                cmd.extend(('-i', str(tracks[0])))
+        except:
+            pass
+        return cmd
 
     def convert(self, path):
         infile = self.get_input_file(path)
@@ -178,21 +195,8 @@ class FFMPEGIFY():
                 cmd.extend(('-r', str(self.FRAME_RATE)))
                 cmd.extend(('-i', inputf_abs))
 
-                # AUDIO
-                try:
-                    tracks = []
-                    tracks.extend(sorted(infile.parent.glob('*.mp3')))
-                    tracks.extend(sorted(infile.parent.glob('*.wav')))
-                    # also search immediate parent?
-                    tracks.extend(sorted(infile.parents[1].glob('*.mp3')))
-                    tracks.extend(sorted(infile.parents[1].glob('*.wav')))
-                    if (tracks):
-                        self.AUDIO = True
-                        # audio track offset - add controls for this?
-                        cmd.extend(('-itsoffset', str(self.AUDIO_OFFSET)))
-                        cmd.extend(('-i', str(tracks[0])))
-                except:
-                    pass
+                cmd = self.add_audio(infile, cmd)
+
                 if self.isVidOut:
                     # Codecs TODO DNxHR and ProRes?
                     if self.CODEC == "H.264":

--- a/ffmpegify.py
+++ b/ffmpegify.py
@@ -44,11 +44,9 @@ class FFMPEGIFY():
             self.isVidOut = False
 
 
-    def convert(self, path, config):
+    def get_input_file(self, path):
+        # Parse filename
         infile = pathlib.Path(path)
-        saveDir = infile  # set the directory to save the output to
-
-        # For Directories
         if os.path.isdir(path):
             files = os.listdir(path)
             for f in files:
@@ -56,6 +54,13 @@ class FFMPEGIFY():
                 if fpath.suffix in alltypes:
                     infile = infile.joinpath(fpath)
                     break
+        return infile
+
+
+    def convert(self, path):
+        infile = self.get_input_file(path)
+        saveDir = infile  # set the directory to save the output to
+
         stem = infile.stem
         suffix = infile.suffix
 
@@ -239,5 +244,5 @@ if __name__ == '__main__':
     path = Path(sys.argv[0]).with_name('settings.json')
     config = readSettings(path)
     F = FFMPEGIFY(config)
-    F.convert(sys.argv[1], config)
+    F.convert(sys.argv[1])
     # input()

--- a/ffmpegify.py
+++ b/ffmpegify.py
@@ -57,9 +57,33 @@ class FFMPEGIFY():
         return infile
 
 
+    def get_output_filename(self, infile):
+        # OUTPUT FILENAME
+        saveDir = infile # naming the video file based on parent dir. Could change this later.
+        parts = infile.parent.parts
+        if (self.NAME_LEVELS > 0):
+            sec = len(parts) - self.NAME_LEVELS
+            parts = parts[sec:]
+            outname = "_".join(parts)
+        else:
+            outname = str(infile.parent)
+        outname = re.sub(r'\W+', '_', outname)
+        outputf = str(saveDir.with_name('_' + outname + "_video." + self.VIDFORMAT))
+        if not self.isVidOut:
+            outputf = str(saveDir.with_name('_' + preframepart + "_" + padstring + "." + self.VIDFORMAT))
+
+        # if the video already exists create do not overwrite it
+        counter = 1
+        while pathlib.Path(outputf).exists():
+            outputf = str(saveDir.with_name('_' + outname + "_video_" + str(counter) + "." + self.VIDFORMAT))
+            counter = counter + 1
+        return outputf
+
+
+
+
     def convert(self, path):
         infile = self.get_input_file(path)
-        saveDir = infile  # set the directory to save the output to
 
         stem = infile.stem
         suffix = infile.suffix
@@ -102,25 +126,8 @@ class FFMPEGIFY():
                 inputf = stem[0:sp2[0]] + padstring + postframepart + suffix
                 inputf_abs = str(infile.with_name(inputf))
 
-                # naming the video file based on parent dirs
-                parts = infile.parent.parts
-                if (self.NAME_LEVELS > 0):
-                    sec = len(parts) - self.NAME_LEVELS
-                    parts = parts[sec:]
-                    outname = "_".join(parts)
-                else:
-                    outname = str(infile.parent)
-                outname = re.sub(r'\W+', '_', outname)
+                outputf = self.output_filename(inputf)
 
-                outputf = str(saveDir.with_name('_' + outname + "_video." + self.VIDFORMAT))
-                if not self.isVidOut:
-                    outputf = str(saveDir.with_name('_' + preframepart + "_" + padstring + "." + self.VIDFORMAT))
-
-                # if the video already exists create do not overwrite it
-                counter = 1
-                while pathlib.Path(outputf).exists():
-                    outputf = str(saveDir.with_name('_' + outname + "_video_" + str(counter) + "." + self.VIDFORMAT))
-                    counter = counter + 1
 
                 # scale down video if the image dimensions exceed the max width or height, while maintaining aspect ratio
                 if self.MAX_HEIGHT <= 0 and self.MAX_WIDTH <= 0:

--- a/ffmpegify.py
+++ b/ffmpegify.py
@@ -11,215 +11,222 @@ import time
 import json
 
 
-def convert(path, config):
-    # get config settings
-    START_FRAME = int(config['startFrame'])
-    MAX_FRAMES = int(config['maxFrames'])
-    MAX_WIDTH = int(config['maxWidth'])
-    MAX_HEIGHT = int(config['maxHeight'])
-    SCALER = config['scaler']
-    CRF = int(config['quality'])
-    FRAME_RATE = int(config['FPS'])
-    PRESET = config['preset']
-    CODEC = config['codec']
-    VIDFORMAT = config['format']
-    GAMMA = config['gamma']
-    PREMULT = int(config['premult'])
-    NAME_LEVELS = int(config['namelevels'])
+standard = ['.jpg', '.jpeg', '.png', '.tiff', '.tif']
+gamma = ['.exr', '.tga']
+alltypes = standard + gamma
+vid_suff = ['.mov', '.mp4', '.webm', '.mkv', '.avi'] # do vid-vid conversion with audio as well?
+vids = ['mov', 'mp4', 'mp4-via-jpg']
 
-    AUDIO = False
-    AUDIO_OFFSET = int(config['audiooffset'])
 
-    standard = ['.jpg', '.jpeg', '.png', '.tiff', '.tif']
-    gamma = ['.exr', '.tga']
-    alltypes = standard + gamma
-    vid_suff = ['.mov', '.mp4', '.webm', '.mkv', '.avi'] # do vid-vid conversion with audio as well?
 
-    # Check if being output to video or frames
-    isVidOut = True
-    vids = ['mov', 'mp4', 'mp4-via-jpg']
-    if VIDFORMAT not in vids:
-        isVidOut = False
+class FFMPEGIFY():
+    def __init__(self, config):
+        pass
 
-    file = pathlib.Path(path)
-    saveDir = file  # set the directory to save the output to
 
-    # For Directories
-    if os.path.isdir(path):
-        files = os.listdir(path)
-        for f in files:
-            fpath = pathlib.Path(f)
-            if fpath.suffix in alltypes:
-                file = file.joinpath(fpath)
-                break
-    stem = file.stem
-    suffix = file.suffix
+    def convert(self, path, config):
+        # get config settings
+        START_FRAME = int(config['startFrame'])
+        MAX_FRAMES = int(config['maxFrames'])
+        MAX_WIDTH = int(config['maxWidth'])
+        MAX_HEIGHT = int(config['maxHeight'])
+        SCALER = config['scaler']
+        CRF = int(config['quality'])
+        FRAME_RATE = int(config['FPS'])
+        PRESET = config['preset']
+        CODEC = config['codec']
+        VIDFORMAT = config['format']
+        GAMMA = config['gamma']
+        PREMULT = int(config['premult'])
+        NAME_LEVELS = int(config['namelevels'])
 
-    # create ffmpeg command to append to
-    platform = sys.platform
-    if platform == "win32":
-        cmd = ['ffmpeg']
-    elif platform.startswith('linux'):  # full path to ffmpeg for linux
-        cmd = ['/usr/bin/ffmpeg']
-    else:  # full path to ffmpeg for osx
-        cmd = ['/usr/local/bin/ffmpeg']
+        AUDIO = False
+        AUDIO_OFFSET = int(config['audiooffset'])
 
-    if (suffix in alltypes):
-        l = len(stem)
-        back = stem[::-1]
-        m = re.search('\d+', back)
-        if (m):
-            # simple regex match - find digit from the end of the stem
-            sp = m.span(0)
-            sp2 = [l - a for a in sp]
-            sp2.reverse()
+        # Check if being output to video or frames
+        isVidOut = True
+        if VIDFORMAT not in vids:
+            isVidOut = False
 
-            # glob for other frames in the folder and find the first frame to use as start number
-            preframepart = stem[0:sp2[0]]
-            postframepart = stem[sp2[1]:]
-            frames = sorted(file.parent.glob(preframepart + '*' + postframepart + suffix))
-            start_num = int(frames[0].name[sp2[0]:sp2[1]])
-            if START_FRAME > 0:
-                start_num = START_FRAME
+        file = pathlib.Path(path)
+        saveDir = file  # set the directory to save the output to
 
-            # get padding for frame num
-            padding = sp2[1] - sp2[0]
-            padstring = '%' + format(padding, '02') + 'd'  # eg %05d
-            # fix for unpadded frame numbers
-            if len(frames[0].name) != len(frames[-1].name):
-                padstring = '%' + 'd'
+        # For Directories
+        if os.path.isdir(path):
+            files = os.listdir(path)
+            for f in files:
+                fpath = pathlib.Path(f)
+                if fpath.suffix in alltypes:
+                    file = file.joinpath(fpath)
+                    break
+        stem = file.stem
+        suffix = file.suffix
 
-            # get absolute path to the input file and set the outputfile
-            inputf = stem[0:sp2[0]] + padstring + postframepart + suffix
-            inputf_abs = str(file.with_name(inputf))
+        # create ffmpeg command to append to
+        platform = sys.platform
+        if platform == "win32":
+            cmd = ['ffmpeg']
+        elif platform.startswith('linux'):  # full path to ffmpeg for linux
+            cmd = ['/usr/bin/ffmpeg']
+        else:  # full path to ffmpeg for osx
+            cmd = ['/usr/local/bin/ffmpeg']
 
-            # naming the video file based on parent dirs
-            parts = file.parent.parts
-            if (NAME_LEVELS > 0):
-                sec = len(parts) - NAME_LEVELS
-                parts = parts[sec:]
-                outname = "_".join(parts)
-            else:
-                outname = str(file.parent)
-            outname = re.sub(r'\W+', '_', outname)
+        if (suffix in alltypes):
+            l = len(stem)
+            back = stem[::-1]
+            m = re.search('\d+', back)
+            if (m):
+                # simple regex match - find digit from the end of the stem
+                sp = m.span(0)
+                sp2 = [l - a for a in sp]
+                sp2.reverse()
 
-            outputf = str(saveDir.with_name('_' + outname + "_video." + VIDFORMAT))
-            if not isVidOut:
-                outputf = str(saveDir.with_name('_' + preframepart + "_" + padstring + "." + VIDFORMAT))
+                # glob for other frames in the folder and find the first frame to use as start number
+                preframepart = stem[0:sp2[0]]
+                postframepart = stem[sp2[1]:]
+                frames = sorted(file.parent.glob(preframepart + '*' + postframepart + suffix))
+                start_num = int(frames[0].name[sp2[0]:sp2[1]])
+                if START_FRAME > 0:
+                    start_num = START_FRAME
 
-            # if the video already exists create do not overwrite it
-            counter = 1
-            while pathlib.Path(outputf).exists():
-                outputf = str(saveDir.with_name('_' + outname + "_video_" + str(counter) + "." + VIDFORMAT))
-                counter = counter + 1
+                # get padding for frame num
+                padding = sp2[1] - sp2[0]
+                padstring = '%' + format(padding, '02') + 'd'  # eg %05d
+                # fix for unpadded frame numbers
+                if len(frames[0].name) != len(frames[-1].name):
+                    padstring = '%' + 'd'
 
-            # scale down video if the image dimensions exceed the max width or height, while maintaining aspect ratio
-            if MAX_HEIGHT <= 0 and MAX_WIDTH <= 0:
-                scalestr = "scale='trunc(iw/2)*2':'trunc(ih/2)*2'"
-            elif MAX_WIDTH <= 0:
-                scalestr = "scale='-2:min'(" + str(MAX_HEIGHT) + ",trunc(ih/2)*2)':force_original_aspect_ratio=decrease"
-            elif MAX_HEIGHT <= 0:
-                scalestr = "scale='min(" + str(MAX_WIDTH) + ",trunc(iw/2)*2)':-2"
-            else:
-                # this currently causes issues if the W or H are greater than the max, and the other dimension is no longer divisible by 2 when scaled down so pad it
-                scalestr = "scale='min(" + str(MAX_WIDTH) + ",trunc(iw/2)*2)':min'(" + str(MAX_HEIGHT) + ",trunc(ih/2)*2)':force_original_aspect_ratio=decrease,pad=" + str(MAX_WIDTH) + ":" + str(MAX_HEIGHT) + ":(ow-iw)/2:(oh-ih)/2"
-                # maybe skip force ratio and do it manually? DOesnt work yet...
-                max_asp = float(MAX_WIDTH) / MAX_HEIGHT
-                A = "min(trunc(iw/2)*2," + str(MAX_WIDTH) + ")"
-                B = "if( gt(ih," + str(MAX_HEIGHT) + "), trunc((" + str(MAX_HEIGHT) + "*dar)/2)*2, -2 )"
-                C = "if(gt(iw," + str(MAX_WIDTH) + "), trunc((" + str(MAX_WIDTH) + "/dar)/2)*2 ,-2)"
-                D = "min( trunc(ih/2)*2," + str(MAX_HEIGHT) + ")"
-                scalestr = "scale='if( gt(dar," + str(max_asp) + "), " + A + ", " + B + ")':'if( gt(dar," + str(max_asp) + "), " + C + ", " + D + " )'"
+                # get absolute path to the input file and set the outputfile
+                inputf = stem[0:sp2[0]] + padstring + postframepart + suffix
+                inputf_abs = str(file.with_name(inputf))
 
-            # ============================================
-            # FFPROBE - Probably easier to use this metadata
-            # =============================================
-            # ffprobe = ['ffprobe']
-            # ffprobe.extend(('-v', 'quiet'))
-            # ffprobe.extend(('-print_format', 'json'))
-            # ffprobe.append(str(file))
-            # ffprobe.append('-show_format')
-            # ffprobe.append('-show_streams')
-            # ffpr = subprocess.check_output(ffprobe)
-            # ffjson = json.loads(ffpr)
-            # IN_W = ffjson['streams'][0]['coded_width']
-            # IN_H = ffjson['streams'][0]['coded_height']
-            # IN_DURATION = ffjson['streams'][0]['duration']
-            # IN_FRAMES = int(ffjson['streams'][0]['nb_frames'])
-            # IN_FPS = ffjson['streams'][0]['r_frame_rate']
-            # ===================================
-
-            if (suffix in gamma):
-                cmd.extend(('-gamma', GAMMA))
-            cmd.extend(('-start_number', str(start_num).zfill(padding)))
-            cmd.extend(('-r', str(FRAME_RATE)))
-            cmd.extend(('-i', inputf_abs))
-
-            # AUDIO
-            try:
-                tracks = []
-                tracks.extend(sorted(file.parent.glob('*.mp3')))
-                tracks.extend(sorted(file.parent.glob('*.wav')))
-                # also search immediate parent?
-                tracks.extend(sorted(file.parents[1].glob('*.mp3')))
-                tracks.extend(sorted(file.parents[1].glob('*.wav')))
-                if (tracks):
-                    AUDIO = True
-                    # audio track offset - add controls for this?
-                    cmd.extend(('-itsoffset', str(AUDIO_OFFSET)))
-                    cmd.extend(('-i', str(tracks[0])))
-            except:
-                pass
-            if isVidOut:
-                # Codecs TODO DNxHR and ProRes?
-                if CODEC == "H.264":
-                    cmd.extend(('-c:v', 'libx264'))
-                    cmd.extend(('-pix_fmt', 'yuv420p', '-crf', str(CRF), '-preset', PRESET))
-                    # colours are always slightly off... not sure how to fix. libx264rgb seems to help but still not right?
-                    # cmd.extend(('-c:v', 'libx264rgb'))
-                    # cmd.extend(('-pix_fmt', 'yuv444p', '-crf', str(CRF), '-preset', PRESET))
-                elif CODEC == "DNxHR":
-                    cmd.extend(('-c:v', 'dnxhd'))
-                    cmd.extend(('-profile', 'dnxhr_hq'))
+                # naming the video file based on parent dirs
+                parts = file.parent.parts
+                if (NAME_LEVELS > 0):
+                    sec = len(parts) - NAME_LEVELS
+                    parts = parts[sec:]
+                    outname = "_".join(parts)
                 else:
-                    pass
+                    outname = str(file.parent)
+                outname = re.sub(r'\W+', '_', outname)
 
-            if MAX_FRAMES > 0:
-                cmd.extend(('-vframes', str(MAX_FRAMES)))
-            if isVidOut:
-                if PREMULT:
-                    cmd.extend(('-vf', 'premultiply=inplace=1, ' + scalestr)) # premult is causing all the problems?? Leave it off...
+                outputf = str(saveDir.with_name('_' + outname + "_video." + VIDFORMAT))
+                if not isVidOut:
+                    outputf = str(saveDir.with_name('_' + preframepart + "_" + padstring + "." + VIDFORMAT))
+
+                # if the video already exists create do not overwrite it
+                counter = 1
+                while pathlib.Path(outputf).exists():
+                    outputf = str(saveDir.with_name('_' + outname + "_video_" + str(counter) + "." + VIDFORMAT))
+                    counter = counter + 1
+
+                # scale down video if the image dimensions exceed the max width or height, while maintaining aspect ratio
+                if MAX_HEIGHT <= 0 and MAX_WIDTH <= 0:
+                    scalestr = "scale='trunc(iw/2)*2':'trunc(ih/2)*2'"
+                elif MAX_WIDTH <= 0:
+                    scalestr = "scale='-2:min'(" + str(MAX_HEIGHT) + ",trunc(ih/2)*2)':force_original_aspect_ratio=decrease"
+                elif MAX_HEIGHT <= 0:
+                    scalestr = "scale='min(" + str(MAX_WIDTH) + ",trunc(iw/2)*2)':-2"
+                else:
+                    # this currently causes issues if the W or H are greater than the max, and the other dimension is no longer divisible by 2 when scaled down so pad it
+                    scalestr = "scale='min(" + str(MAX_WIDTH) + ",trunc(iw/2)*2)':min'(" + str(MAX_HEIGHT) + ",trunc(ih/2)*2)':force_original_aspect_ratio=decrease,pad=" + str(MAX_WIDTH) + ":" + str(MAX_HEIGHT) + ":(ow-iw)/2:(oh-ih)/2"
+                    # maybe skip force ratio and do it manually? DOesnt work yet...
+                    max_asp = float(MAX_WIDTH) / MAX_HEIGHT
+                    A = "min(trunc(iw/2)*2," + str(MAX_WIDTH) + ")"
+                    B = "if( gt(ih," + str(MAX_HEIGHT) + "), trunc((" + str(MAX_HEIGHT) + "*dar)/2)*2, -2 )"
+                    C = "if(gt(iw," + str(MAX_WIDTH) + "), trunc((" + str(MAX_WIDTH) + "/dar)/2)*2 ,-2)"
+                    D = "min( trunc(ih/2)*2," + str(MAX_HEIGHT) + ")"
+                    scalestr = "scale='if( gt(dar," + str(max_asp) + "), " + A + ", " + B + ")':'if( gt(dar," + str(max_asp) + "), " + C + ", " + D + " )'"
+
+                # ============================================
+                # FFPROBE - Probably easier to use this metadata
+                # =============================================
+                # ffprobe = ['ffprobe']
+                # ffprobe.extend(('-v', 'quiet'))
+                # ffprobe.extend(('-print_format', 'json'))
+                # ffprobe.append(str(file))
+                # ffprobe.append('-show_format')
+                # ffprobe.append('-show_streams')
+                # ffpr = subprocess.check_output(ffprobe)
+                # ffjson = json.loads(ffpr)
+                # IN_W = ffjson['streams'][0]['coded_width']
+                # IN_H = ffjson['streams'][0]['coded_height']
+                # IN_DURATION = ffjson['streams'][0]['duration']
+                # IN_FRAMES = int(ffjson['streams'][0]['nb_frames'])
+                # IN_FPS = ffjson['streams'][0]['r_frame_rate']
+                # ===================================
+
+                if (suffix in gamma):
+                    cmd.extend(('-gamma', GAMMA))
+                cmd.extend(('-start_number', str(start_num).zfill(padding)))
+                cmd.extend(('-r', str(FRAME_RATE)))
+                cmd.extend(('-i', inputf_abs))
+
+                # AUDIO
+                try:
+                    tracks = []
+                    tracks.extend(sorted(file.parent.glob('*.mp3')))
+                    tracks.extend(sorted(file.parent.glob('*.wav')))
+                    # also search immediate parent?
+                    tracks.extend(sorted(file.parents[1].glob('*.mp3')))
+                    tracks.extend(sorted(file.parents[1].glob('*.wav')))
+                    if (tracks):
+                        AUDIO = True
+                        # audio track offset - add controls for this?
+                        cmd.extend(('-itsoffset', str(AUDIO_OFFSET)))
+                        cmd.extend(('-i', str(tracks[0])))
+                except:
+                    pass
+                if isVidOut:
+                    # Codecs TODO DNxHR and ProRes?
+                    if CODEC == "H.264":
+                        cmd.extend(('-c:v', 'libx264'))
+                        cmd.extend(('-pix_fmt', 'yuv420p', '-crf', str(CRF), '-preset', PRESET))
+                        # colours are always slightly off... not sure how to fix. libx264rgb seems to help but still not right?
+                        # cmd.extend(('-c:v', 'libx264rgb'))
+                        # cmd.extend(('-pix_fmt', 'yuv444p', '-crf', str(CRF), '-preset', PRESET))
+                    elif CODEC == "DNxHR":
+                        cmd.extend(('-c:v', 'dnxhd'))
+                        cmd.extend(('-profile', 'dnxhr_hq'))
+                    else:
+                        pass
+
+                if MAX_FRAMES > 0:
+                    cmd.extend(('-vframes', str(MAX_FRAMES)))
+                if isVidOut:
+                    if PREMULT:
+                        cmd.extend(('-vf', 'premultiply=inplace=1, ' + scalestr)) # premult is causing all the problems?? Leave it off...
+                    else:
+                        cmd.extend(('-vf', scalestr))
                 else:
                     cmd.extend(('-vf', scalestr))
+                cmd.extend(('-sws_flags', SCALER))
+                if VIDFORMAT == 'jpg':
+                    cmd.extend(('-q:v', '2'))
+                # AUDIO OPTIONS
+                if AUDIO:
+                    cmd.extend(('-c:a', 'aac'))
+                    cmd.extend(('-b:a', '320k'))
+                    cmd.append('-shortest')
+                cmd.append(outputf)
+                subprocess.run(cmd)
             else:
-                cmd.extend(('-vf', scalestr))
-            cmd.extend(('-sws_flags', SCALER))
-            if VIDFORMAT == 'jpg':
-                cmd.extend(('-q:v', '2'))
-            # AUDIO OPTIONS
-            if AUDIO:
-                cmd.extend(('-c:a', 'aac'))
-                cmd.extend(('-b:a', '320k'))
-                cmd.append('-shortest')
+                pass
+        # ==================================
+        # Vid-Vid conversion (with audio)
+        # TODO
+        # ==================================
+        elif suffix in vid_suff:
+            cmd.extend(('-i', file))
+            if CODEC == "H.264":
+                cmd.extend(('-c:v', 'libx264'))
+                cmd.extend(('-pix_fmt', 'yuv420p', '-crf', str(CRF), '-preset', PRESET))
+
+            outputf = str(saveDir.with_name(stem + "_converted." + VIDFORMAT))
             cmd.append(outputf)
             subprocess.run(cmd)
         else:
-            pass
-    # ==================================
-    # Vid-Vid conversion (with audio)
-    # TODO
-    # ==================================
-    elif suffix in vid_suff:
-        cmd.extend(('-i', file))
-        if CODEC == "H.264":
-            cmd.extend(('-c:v', 'libx264'))
-            cmd.extend(('-pix_fmt', 'yuv420p', '-crf', str(CRF), '-preset', PRESET))
-
-        outputf = str(saveDir.with_name(stem + "_converted." + VIDFORMAT))
-        cmd.append(outputf)
-        subprocess.run(cmd)
-    else:
-        print("Invalid file extension")
+            print("Invalid file extension")
 
 # Read config file for settings
 def readSettings(settings):
@@ -234,5 +241,6 @@ def readSettings(settings):
 if __name__ == '__main__':
     path = Path(sys.argv[0]).with_name('settings.json')
     config = readSettings(path)
-    convert(sys.argv[1], config)
+    F = FFMPEGIFY(config)
+    F.convert(sys.argv[1], config)
     # input()

--- a/ffmpegify.py
+++ b/ffmpegify.py
@@ -79,7 +79,10 @@ class FFMPEGIFY():
             counter = counter + 1
         return outputf
 
-    def input_stream(self, infile):
+
+    def input_stream(self, infile, cmd):
+        stem = infile.stem
+        suffix = infile.suffix
         l = len(stem)
         back = stem[::-1]
         m = re.search('\d+', back)
@@ -127,8 +130,16 @@ class FFMPEGIFY():
             # IN_FPS = ffjson['streams'][0]['r_frame_rate']
             # ===================================
 
-            return (inputf, inputf_abs, start_num)
-        return (None, None, None)
+
+            if (suffix in gamma):
+                cmd.extend(('-gamma', self.GAMMA))
+            cmd.extend(('-start_number', str(start_num).zfill(padding)))
+            cmd.extend(('-r', str(self.FRAME_RATE)))
+            cmd.extend(('-i', inputf_abs))
+
+            return cmd
+        return None
+
 
 
     def add_audio(self, infile, cmd):
@@ -181,8 +192,6 @@ class FFMPEGIFY():
 
     def convert(self, path):
         infile = self.get_input_file(path)
-
-        stem = infile.stem
         suffix = infile.suffix
 
         # create ffmpeg command to append to
@@ -196,21 +205,13 @@ class FFMPEGIFY():
 
         if (suffix in alltypes):
 
-            inputf, inputf_abs, start_num = input_stream(infile)
+            cmd = self.input_stream(infile, cmd)
 
-            if not inputf:
-                print("Cannot find input file")
+            if not cmd:
+                print("Cannot find valid input file")
                 return
 
-            outputf = self.output_filename(inputf)
-
-
-            if (suffix in gamma):
-                cmd.extend(('-gamma', self.GAMMA))
-            cmd.extend(('-start_number', str(start_num).zfill(padding)))
-            cmd.extend(('-r', str(self.FRAME_RATE)))
-            cmd.extend(('-i', inputf_abs))
-
+            outputf = self.output_filename(infile)
             cmd = self.add_audio(infile, cmd)
 
             if self.isVidOut:
@@ -240,6 +241,7 @@ class FFMPEGIFY():
                 cmd.append('-shortest')
             cmd.append(outputf)
             subprocess.run(cmd)
+
         # ==================================
         # Vid-Vid conversion (with audio)
         # TODO

--- a/ffmpegify.py
+++ b/ffmpegify.py
@@ -197,47 +197,49 @@ class FFMPEGIFY():
         if (suffix in alltypes):
 
             inputf, inputf_abs, start_num = input_stream(infile)
-            if inputf:
-                outputf = self.output_filename(inputf)
+
+            if not inputf:
+                print("Cannot find input file")
+                return
+
+            outputf = self.output_filename(inputf)
 
 
-                if (suffix in gamma):
-                    cmd.extend(('-gamma', self.GAMMA))
-                cmd.extend(('-start_number', str(start_num).zfill(padding)))
-                cmd.extend(('-r', str(self.FRAME_RATE)))
-                cmd.extend(('-i', inputf_abs))
+            if (suffix in gamma):
+                cmd.extend(('-gamma', self.GAMMA))
+            cmd.extend(('-start_number', str(start_num).zfill(padding)))
+            cmd.extend(('-r', str(self.FRAME_RATE)))
+            cmd.extend(('-i', inputf_abs))
 
-                cmd = self.add_audio(infile, cmd)
+            cmd = self.add_audio(infile, cmd)
 
-                if self.isVidOut:
-                    # Codecs TODO DNxHR and ProRes?
-                    if self.CODEC == "H.264":
-                        cmd.extend(('-c:v', 'libx264'))
-                        cmd.extend(('-pix_fmt', 'yuv420p', '-crf', str(self.CRF), '-preset', self.PRESET))
-                        # colours are always slightly off... not sure how to fix. libx264rgb seems to help but still not right?
-                        # cmd.extend(('-c:v', 'libx264rgb'))
-                        # cmd.extend(('-pix_fmt', 'yuv444p', '-crf', str(self.CRF), '-preset', self.PRESET))
-                    elif self.CODEC == "DNxHR":
-                        cmd.extend(('-c:v', 'dnxhd'))
-                        cmd.extend(('-profile', 'dnxhr_hq'))
-                    else:
-                        pass
+            if self.isVidOut:
+                # Codecs TODO DNxHR and ProRes?
+                if self.CODEC == "H.264":
+                    cmd.extend(('-c:v', 'libx264'))
+                    cmd.extend(('-pix_fmt', 'yuv420p', '-crf', str(self.CRF), '-preset', self.PRESET))
+                    # colours are always slightly off... not sure how to fix. libx264rgb seems to help but still not right?
+                    # cmd.extend(('-c:v', 'libx264rgb'))
+                    # cmd.extend(('-pix_fmt', 'yuv444p', '-crf', str(self.CRF), '-preset', self.PRESET))
+                elif self.CODEC == "DNxHR":
+                    cmd.extend(('-c:v', 'dnxhd'))
+                    cmd.extend(('-profile', 'dnxhr_hq'))
+                else:
+                    pass
 
-                if self.MAX_FRAMES > 0:
-                    cmd.extend(('-vframes', str(self.MAX_FRAMES)))
+            if self.MAX_FRAMES > 0:
+                cmd.extend(('-vframes', str(self.MAX_FRAMES)))
 
-                cmd = self.add_scaling(cmd)
-                if self.VIDFORMAT == 'jpg':
-                    cmd.extend(('-q:v', '2'))
-                # AUDIO OPTIONS
-                if self.AUDIO:
-                    cmd.extend(('-c:a', 'aac'))
-                    cmd.extend(('-b:a', '320k'))
-                    cmd.append('-shortest')
-                cmd.append(outputf)
-                subprocess.run(cmd)
-            else:
-                pass
+            cmd = self.add_scaling(cmd)
+            if self.VIDFORMAT == 'jpg':
+                cmd.extend(('-q:v', '2'))
+            # AUDIO OPTIONS
+            if self.AUDIO:
+                cmd.extend(('-c:a', 'aac'))
+                cmd.extend(('-b:a', '320k'))
+                cmd.append('-shortest')
+            cmd.append(outputf)
+            subprocess.run(cmd)
         # ==================================
         # Vid-Vid conversion (with audio)
         # TODO

--- a/ffmpegify.py
+++ b/ffmpegify.py
@@ -16,7 +16,7 @@ standard = ['.jpg', '.jpeg', '.png', '.tiff', '.tif']
 gamma = ['.exr', '.tga']
 alltypes = standard + gamma
 vid_suff = ['.mov', '.mp4', '.webm', '.mkv', '.avi'] # do vid-vid conversion with audio as well?
-vids = ['mov', 'mp4', 'mp4-via-jpg']
+vids = ['mov', 'mp4', 'mp4-via-jpg', 'webm']
 
 
 
@@ -229,6 +229,13 @@ class FFMPEGIFY():
                 pass
         elif self.VIDFORMAT == 'jpg':
             OUT_ARGS['q:v'] = '2'
+
+        if self.VIDFORMAT == 'webm':
+            # Possibly implement two-pass for webm
+            OUT_ARGS = dict()
+            OUT_ARGS['crf'] = str(self.CRF)
+            OUT_ARGS['vcodec'] = "libvpx"
+            OUT_ARGS['b:v'] = 0
 
 
         if self.MAX_FRAMES > 0:

--- a/ffmpegify.py
+++ b/ffmpegify.py
@@ -39,13 +39,12 @@ class FFMPEGIFY():
         self.AUDIO = False
         self.AUDIO_OFFSET = int(config['audiooffset'])
 
+        self.isVidOut = True # Check if being output to video or frames
+        if self.VIDFORMAT not in vids:
+            self.isVidOut = False
+
 
     def convert(self, path, config):
-        # Check if being output to video or frames
-        isVidOut = True
-        if self.VIDFORMAT not in vids:
-            isVidOut = False
-
         infile = pathlib.Path(path)
         saveDir = infile  # set the directory to save the output to
 
@@ -109,7 +108,7 @@ class FFMPEGIFY():
                 outname = re.sub(r'\W+', '_', outname)
 
                 outputf = str(saveDir.with_name('_' + outname + "_video." + self.VIDFORMAT))
-                if not isVidOut:
+                if not self.isVidOut:
                     outputf = str(saveDir.with_name('_' + preframepart + "_" + padstring + "." + self.VIDFORMAT))
 
                 # if the video already exists create do not overwrite it
@@ -175,7 +174,7 @@ class FFMPEGIFY():
                         cmd.extend(('-i', str(tracks[0])))
                 except:
                     pass
-                if isVidOut:
+                if self.isVidOut:
                     # Codecs TODO DNxHR and ProRes?
                     if self.CODEC == "H.264":
                         cmd.extend(('-c:v', 'libx264'))
@@ -191,7 +190,7 @@ class FFMPEGIFY():
 
                 if self.MAX_FRAMES > 0:
                     cmd.extend(('-vframes', str(self.MAX_FRAMES)))
-                if isVidOut:
+                if self.isVidOut:
                     if self.PREMULT:
                         cmd.extend(('-vf', 'premultiply=inplace=1, ' + scalestr)) # premult is causing all the problems?? Leave it off...
                     else:

--- a/ffmpegify.py
+++ b/ffmpegify.py
@@ -189,6 +189,37 @@ class FFMPEGIFY():
         cmd.extend(('-sws_flags', self.SCALER))
         return cmd
 
+    def build_output(self, outputf, cmd):
+        if self.isVidOut:
+            # Codecs TODO DNxHR and ProRes?
+            if self.CODEC == "H.264":
+                cmd.extend(('-c:v', 'libx264'))
+                cmd.extend(('-pix_fmt', 'yuv420p', '-crf', str(self.CRF), '-preset', self.PRESET))
+                # colours are always slightly off... not sure how to fix. libx264rgb seems to help but still not right?
+                # cmd.extend(('-c:v', 'libx264rgb'))
+                # cmd.extend(('-pix_fmt', 'yuv444p', '-crf', str(self.CRF), '-preset', self.PRESET))
+            elif self.CODEC == "DNxHR":
+                cmd.extend(('-c:v', 'dnxhd'))
+                cmd.extend(('-profile', 'dnxhr_hq'))
+            else:
+                pass
+
+        if self.MAX_FRAMES > 0:
+            cmd.extend(('-vframes', str(self.MAX_FRAMES)))
+
+        cmd = self.add_scaling(cmd)
+
+        if self.VIDFORMAT == 'jpg':
+            cmd.extend(('-q:v', '2'))
+        # AUDIO OPTIONS
+        if self.AUDIO:
+            cmd.extend(('-c:a', 'aac'))
+            cmd.extend(('-b:a', '320k'))
+            cmd.append('-shortest')
+        cmd.append(outputf)
+
+        return cmd
+
 
     def convert(self, path):
         infile = self.get_input_file(path)
@@ -213,33 +244,7 @@ class FFMPEGIFY():
 
             outputf = self.output_filename(infile)
             cmd = self.add_audio(infile, cmd)
-
-            if self.isVidOut:
-                # Codecs TODO DNxHR and ProRes?
-                if self.CODEC == "H.264":
-                    cmd.extend(('-c:v', 'libx264'))
-                    cmd.extend(('-pix_fmt', 'yuv420p', '-crf', str(self.CRF), '-preset', self.PRESET))
-                    # colours are always slightly off... not sure how to fix. libx264rgb seems to help but still not right?
-                    # cmd.extend(('-c:v', 'libx264rgb'))
-                    # cmd.extend(('-pix_fmt', 'yuv444p', '-crf', str(self.CRF), '-preset', self.PRESET))
-                elif self.CODEC == "DNxHR":
-                    cmd.extend(('-c:v', 'dnxhd'))
-                    cmd.extend(('-profile', 'dnxhr_hq'))
-                else:
-                    pass
-
-            if self.MAX_FRAMES > 0:
-                cmd.extend(('-vframes', str(self.MAX_FRAMES)))
-
-            cmd = self.add_scaling(cmd)
-            if self.VIDFORMAT == 'jpg':
-                cmd.extend(('-q:v', '2'))
-            # AUDIO OPTIONS
-            if self.AUDIO:
-                cmd.extend(('-c:a', 'aac'))
-                cmd.extend(('-b:a', '320k'))
-                cmd.append('-shortest')
-            cmd.append(outputf)
+            cmd = self.build_output(outputf, cmd)
             subprocess.run(cmd)
 
         # ==================================

--- a/ffmpegify.py
+++ b/ffmpegify.py
@@ -260,6 +260,7 @@ class FFMPEGIFY():
         # Vid-Vid conversion (with audio)
         # TODO
         # ==================================
+        stem = infile.stem
         saveDir = infile
         STREAM = ffmpeg.input(infile)
 

--- a/ffmpegifyConfigure.pyw
+++ b/ffmpegifyConfigure.pyw
@@ -117,6 +117,14 @@ class Example(QDialog):
         self.namelevels_widget.setValue(int(self.cf['namelevels']))
         layout.addRow(self.namelevels_label, self.namelevels_widget)
 
+        # AUDIO
+        self.audio_label = QLabel("Enable Audio")
+        self.audio_widget = QCheckBox()
+        self.audio_widget.setTristate(False)
+        self.audio_widget.setCheckState(int(self.cf['useaudio']))
+        layout.addRow(self.audio_label, self.audio_widget)
+
+
         # AUDIO OFFSET
         self.audiooffset_label = QLabel("Audio Offset (Seconds)")
         self.audiooffset_widget = QSpinBox()
@@ -177,6 +185,7 @@ class Example(QDialog):
         cfg['codec'] = self.codec_widget.currentText()
         cfg['format'] = self.format_widget.currentText()
         cfg['namelevels'] = str(self.namelevels_widget.value())
+        cfg['useaudio'] = str(self.audio_widget.value())
         cfg['audiooffset'] = str(self.audiooffset_widget.value())
         with open(Path(self.loc).with_name('settings.json'), 'w') as f:
             json.dump(cfg, f)

--- a/ffmpegifyConfigure.pyw
+++ b/ffmpegifyConfigure.pyw
@@ -18,7 +18,7 @@ class Example(QDialog):
         self.loc = ffmpegify_loc
         self.initUI()
 
-    def initUI(self):    
+    def initUI(self):
         self.cf = self.readSettings()
 
         # main top level layout
@@ -28,77 +28,77 @@ class Example(QDialog):
         # FRAMERATE
         self.fps_label = QLabel("Frame Rate")
         self.fps_widget = QSpinBox()
-        self.fps_widget.setValue(int(self.cf['FPS']))    
+        self.fps_widget.setValue(int(self.cf['FPS']))
         layout.addRow(self.fps_label, self.fps_widget)
 
         # QUALITY
         self.cf_label = QLabel("Quality (0-51: Lower=Better Quality)")
         self.cf_widget = QSpinBox()
-        self.cf_widget.setValue(int(self.cf['quality']))    
+        self.cf_widget.setValue(int(self.cf['quality']))
         layout.addRow(self.cf_label, self.cf_widget)
 
         # MAXWIDTH
         self.maxw_label = QLabel("Maximum Width (0 to disable)")
         self.maxw_widget = QSpinBox()
-        self.maxw_widget.setRange(0, 5000)    
-        self.maxw_widget.setValue(int(self.cf['maxWidth']))    
+        self.maxw_widget.setRange(0, 5000)
+        self.maxw_widget.setValue(int(self.cf['maxWidth']))
         layout.addRow(self.maxw_label, self.maxw_widget)
 
         # MAXHEIGHT
         self.maxh_label = QLabel("Maximum Height (0 to disable)")
         self.maxh_widget = QSpinBox()
-        self.maxh_widget.setRange(0, 5000)    
-        self.maxh_widget.setValue(int(self.cf['maxHeight']))    
+        self.maxh_widget.setRange(0, 5000)
+        self.maxh_widget.setValue(int(self.cf['maxHeight']))
         layout.addRow(self.maxh_label, self.maxh_widget)
 
         # SCALER
         self.scaler_label = QLabel("Scaling Algorithm")
         self.scaler_widget = QComboBox()
         for p in self.scalers:
-            self.scaler_widget.addItem(p)        
-        self.scaler_widget.setCurrentText(self.cf['scaler'])            
+            self.scaler_widget.addItem(p)
+        self.scaler_widget.setCurrentText(self.cf['scaler'])
         layout.addRow(self.scaler_label, self.scaler_widget)
 
         # START FRAME
         self.startframe_label = QLabel("Start Frame (0 for first in sequence)")
         self.startframe_widget = QSpinBox()
-        self.startframe_widget.setRange(0, 5000)    
-        self.startframe_widget.setValue(int(self.cf['startFrame']))    
+        self.startframe_widget.setRange(0, 5000)
+        self.startframe_widget.setValue(int(self.cf['startFrame']))
         layout.addRow(self.startframe_label, self.startframe_widget)
 
         # END FRAME (LEN)
         self.endframe_label = QLabel("Max Frames (0 for no maximum)")
         self.endframe_widget = QSpinBox()
-        self.endframe_widget.setRange(0, 5000)    
-        self.endframe_widget.setValue(int(self.cf['maxFrames']))    
+        self.endframe_widget.setRange(0, 5000)
+        self.endframe_widget.setValue(int(self.cf['maxFrames']))
         layout.addRow(self.endframe_label, self.endframe_widget)
 
         # GAMMA
         self.gamma_label = QLabel("Gamma (EXR/TGA only)")
         self.gamma_widget = QDoubleSpinBox()
-        self.gamma_widget.setValue(float(self.cf['gamma']))    
+        self.gamma_widget.setValue(float(self.cf['gamma']))
         layout.addRow(self.gamma_label, self.gamma_widget)
-        
+
         # PREMULT
         self.premult_label = QLabel("Premultiply Alpha")
         self.premult_widget = QCheckBox()
         self.premult_widget.setTristate(False)
         self.premult_widget.setCheckState(int(self.cf['premult']))
         layout.addRow(self.premult_label, self.premult_widget)
-        
+
         # PRESET
         self.preset_label = QLabel("Preset")
         self.preset_widget = QComboBox()
         for p in self.presets:
-            self.preset_widget.addItem(p)   
+            self.preset_widget.addItem(p)
         self.preset_widget.setCurrentText(self.cf['preset'])
         layout.addRow(self.preset_label, self.preset_widget)
-        
+
         # CODEC
         self.codec_label = QLabel("Codec")
         self.codec_widget = QComboBox()
         for p in self.codecs:
-            self.codec_widget.addItem(p)   
+            self.codec_widget.addItem(p)
         self.codec_widget.setCurrentText(self.cf['codec'])
         layout.addRow(self.codec_label, self.codec_widget)
 
@@ -106,57 +106,57 @@ class Example(QDialog):
         self.format_label = QLabel("Format")
         self.format_widget = QComboBox()
         for p in self.formats:
-            self.format_widget.addItem(p)        
-        self.format_widget.setCurrentText(self.cf['format'])            
+            self.format_widget.addItem(p)
+        self.format_widget.setCurrentText(self.cf['format'])
         layout.addRow(self.format_label, self.format_widget)
 
         # NAMING LEVELS
         self.namelevels_label = QLabel("Naming Levels (0 for full path)")
         self.namelevels_widget = QSpinBox()
-        self.namelevels_widget.setRange(0, 10)    
-        self.namelevels_widget.setValue(int(self.cf['namelevels']))    
+        self.namelevels_widget.setRange(0, 10)
+        self.namelevels_widget.setValue(int(self.cf['namelevels']))
         layout.addRow(self.namelevels_label, self.namelevels_widget)
-        
+
         # AUDIO OFFSET
         self.audiooffset_label = QLabel("Audio Offset (Seconds)")
         self.audiooffset_widget = QSpinBox()
-        self.audiooffset_widget.setRange(-200, 200)    
-        self.audiooffset_widget.setValue(int(self.cf['audiooffset']))    
+        self.audiooffset_widget.setRange(-200, 200)
+        self.audiooffset_widget.setValue(int(self.cf['audiooffset']))
         layout.addRow(self.audiooffset_label, self.audiooffset_widget)
-        
+
         # Add form to main layout
-        mainlayout.addLayout(layout)  
-        
+        mainlayout.addLayout(layout)
+
         # Spacer after form
         line = QFrame()
-        line.setMinimumSize(0, 10)             
-        mainlayout.addWidget(line)     
+        line.setMinimumSize(0, 10)
+        mainlayout.addWidget(line)
 
         # ButtonBox
-        self.bbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)    
-        self.bbox.setCenterButtons(True)  
+        self.bbox = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        self.bbox.setCenterButtons(True)
         self.bbox.accepted.connect(self.writeSettings)
         self.bbox.rejected.connect(self.reject)
-        mainlayout.addWidget(self.bbox)      
+        mainlayout.addWidget(self.bbox)
 
-        self.setLayout(mainlayout)  
+        self.setLayout(mainlayout)
         self.setGeometry(300, 300, 250, 150)
-        self.setWindowTitle('FFmpegify Settings')    
-        self.show()        
+        self.setWindowTitle('FFmpegify Settings')
+        self.show()
 
     # Open it under the cursor
     def showEvent(self, event):
         geom = self.frameGeometry()
         geom.moveCenter(QCursor.pos())
         self.setGeometry(geom)
-        super(Example, self).showEvent(event)    
+        super(Example, self).showEvent(event)
 
     # Prevent hitting Enter from pressing OK button
     def keyPressEvent(self, event):
             if event.key() == Qt.Key_Return or event.key() == Qt.Key_Enter:
                 pass
 
-    def readSettings(self):    
+    def readSettings(self):
         with open(Path(self.loc).with_name('settings.json'), 'r') as f:
             config = json.load(f)
         return config

--- a/ffmpegifyConfigure.pyw
+++ b/ffmpegifyConfigure.pyw
@@ -9,7 +9,7 @@ from pathlib import *
 # So much boilerplate...Wow.. Just use Qt Designer...?
 class Example(QDialog):
     presets = ["ultrafast", "superfast", "veryfast", "faster", "fast", "medium", "slow", "slower", "veryslow"]
-    formats = ["mov", "mp4", "png", "tiff", "jpg"]
+    formats = ["mov", "mp4", "webm", "png", "tiff", "jpg"]
     codecs = ["H.264", "DNxHR"]
     scalers = ["bicubic", "bilinear", "lanczos", "neighbor"]
 


### PR DESCRIPTION
Ffmpegify is a great script! I've been it for a while but found it difficult to customize. I've used the library `ffmpeg-python` for small python scripts and thought this could use a rewrite. I tried to break the refactoring apart into two parts: first, I broke the script apart into a class structure with individual functions modifying the `cmd` variable. Once this was finished, I ported from building a command line expression with subprocess.run() to using ffmpeg-python, which is done in the last three commits. I think the result is easier to read and modify and will be much less fragile, e.g. not requiring the path to ffmpeg to be hard-coded, and adding new filters (like an extra crop step) or extra workflows (like video-to-video) becomes very easy. 

You can see the basic idea of how ffmpeg-python changes things by examining commit b369cf2.

Full disclosure: I have not tested audio. I believe line 165 is correct but I haven't actually run it.

The only downside is this modified version will require `pip install ffmpeg-python` on the machines running it. Since this tool already has a significant nontrivial dependency on PyQt5 this is acceptable to me when I've set it up. However if you would rather not pull in another dependency, I think the changes up to 63fe388  are still a significant readability improvement and I would be happy to create a smaller pull request that leaves `ffmpeg-python` out of the picture.